### PR TITLE
feat(vector): adding jsdoc types to factory functions

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -160,8 +160,22 @@ export function calc(alg) {
 
 const colorFactory = cachedFunction((x, y, z, w) => new Color(x, y, z, w));
 
+/**
+ * @param {number | () => number} x
+ * @param {number} [y]
+ * @param {number} [z]
+ * @param {number} [w]
+ * @returns {Color & number}
+ */
 export const color = (x, y, z, w) => colorFactory(x, y, z, w);
 
 const icolorFactory = cachedFunction((x, y, z, w) => new IColor(x, y, z, w));
 
+/**
+ * @param {number | () => number} x
+ * @param {number} [y]
+ * @param {number} [z]
+ * @param {number} [w]
+ * @returns {IColor & number}
+ */
 export const icolor = (x, y, z, w) => icolorFactory(x, y, z, w);

--- a/src/degree.js
+++ b/src/degree.js
@@ -48,10 +48,18 @@ export class IDegree extends ADegree {
 
 const ZERO = new IDegree(0);
 
+/**
+ * @param {number | ADegree} angle
+ * @returns {Degree & number}
+ */
 export function degree(angle) {
   return new Degree(angle);
 }
 
+/**
+ * @param {number | ADegree} angle
+ * @returns {IDegree & number}
+ */
 export function idegree(angle) {
   if (angle instanceof IDegree) {
     return angle;

--- a/src/operator.js
+++ b/src/operator.js
@@ -114,7 +114,7 @@ function setVectorValue(vec, index, value) {
   }
 }
 
-export function operatorCalc(alg, result) {
+export function operatorCalc(alg, result = undefined) {
   if (typeof alg !== 'function') {
     throw new Error('no function assigned');
   }

--- a/src/point.js
+++ b/src/point.js
@@ -207,10 +207,20 @@ export function calc(alg) {
 
 const pointFactory = cachedFunction((x, y) => new Point(x, y));
 
+/**
+ * @param {number | () => number} x
+ * @param {number} [y]
+ * @returns {Point & number}
+ */
 export const point = (x, y) => pointFactory(x, y);
 
 const ipointFactory = cachedFunction((x, y) => new IPoint(x, y));
 
+/**
+ * @param {number | () => number} x
+ * @param {number} [y]
+ * @returns {IPoint & number}
+ */
 export const ipoint = (x, y) => ipointFactory(x, y);
 
 export const ZERO = ipoint(0, 0);

--- a/src/vector.js
+++ b/src/vector.js
@@ -293,10 +293,22 @@ export function calc(alg) {
 
 const vectorFactory = cachedFunction((x, y, z) => new Vector(x, y, z));
 
+/**
+ * @param {number | () => number} x
+ * @param {number} [y]
+ * @param {number} [z]
+ * @returns {Vector & number}
+ */
 export const vector = (x, y, z) => vectorFactory(x, y, z);
 
 const victorFactory = cachedFunction((x, y, z) => new Victor(x, y, z));
 
+/**
+ * @param {number | () => number} x
+ * @param {number} [y]
+ * @param {number} [z]
+ * @returns {Victor & number}
+ */
 export const victor = (x, y, z) => victorFactory(x, y, z);
 
 export const ZERO = victor(0, 0, 0);


### PR DESCRIPTION
first I created `index.d.ts` manually
then i tried to find out in which folder i have to place it
then i realised `unbuild` already creates `d.ts` files for every file

lucky for us, typescript is compatible with jsdoc
https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html

so the code changes are really tiny